### PR TITLE
Wait for network before loading

### DIFF
--- a/custom_components/healthchecksio/manifest.json
+++ b/custom_components/healthchecksio/manifest.json
@@ -3,7 +3,7 @@
   "name": "HealthChecks.io (by Snuffy2)",
   "codeowners": ["@Snuffy2"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["network", "http"],
   "documentation": "https://github.com/Snuffy2/healthchecksio",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Snuffy2/healthchecksio/issues",


### PR DESCRIPTION
Should fix/reduce the errors about not being able to update on HA start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated component requirements to explicitly declare network and HTTP dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->